### PR TITLE
Update gitignore for build artifacts ahead of migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
-target/
 .mooncakes/
 .DS_Store
 build
 .vscode
 
 .cache
-_build/
+_build
 target

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build
 .vscode
 
 .cache
+_build/
+target


### PR DESCRIPTION
## Summary
- Update `.gitignore` to ignore `target` and `_build` directories
- Adjust existing ignore entry to align with upcoming migration needs

## Why
The task requires preparing the repository for future migration and reducing noise from build outputs. Ignoring `target` and `_build` prevents generated artifacts from being tracked and keeps diffs clean.

## Implementation details
- Added explicit ignore patterns for `target` and `_build` in `.gitignore`
- Kept the change focused to a single file as requested
